### PR TITLE
下の階層に*.pyがない場合

### DIFF
--- a/dirimport/_cli.py
+++ b/dirimport/_cli.py
@@ -29,6 +29,13 @@ def generatecmd(path, filename):
     gen.generate(data, path, filename)
 
 
+@cli.command()
+@click.argument("path", type=click.Path(exists=True, dir_okay=True, file_okay=False))
+def dig(path):
+    data = gen.dig(path)
+    print(data)
+
+
 @cli.command("eval")
 @click.argument("path", type=click.Path(exists=True, dir_okay=True, file_okay=False))
 @click.argument("expr")

--- a/dirimport/gen.py
+++ b/dirimport/gen.py
@@ -38,6 +38,8 @@ def dig(dirname):
 def generate(data, basename, filename="__init__.py"):
     dirs, files = data
     ofn = os.path.join(basename, filename)
+    if len(dirs) == 0 and len(files) == 0:
+        return
     with open(ofn, "w") as ofp:
         print(tmpl.render(dirs=dirs.keys(), files=files).strip(), file=ofp)
     for k, v in dirs.items():


### PR DESCRIPTION
下の階層に*.pyが全くないディレクトリを指定してgenerateすると、指定したディレクトリに`__init__.py`ができる。中身はコメントのみ。

`*.py`がない場合はimportしてないしファイルも作ってないので、この場合もないほうがいい。