### PR TITLE
tag.yml: fix version.py quote style to match ruff format

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: versioning
-      run: "echo \"VERSION = '${GITHUB_REF##*/v}'\" > dirimport/_version.py"
+      run: |
+        echo "VERSION = \"${GITHUB_REF##*/v}\"" > dirimport/_version.py
     - uses: wtnb75/actions/python@v1
     - uses: wtnb75/actions/ruff@v1
     - uses: wtnb75/actions/pytest@v1


### PR DESCRIPTION
## Background
Same bug as wtnb75/pstyle#11 (which broke a real `v0.2.1` tag release): `tag.yml`'s `versioning` step writes `VERSION = '$VERSION'` (single-quoted), but the following `wtnb75/actions/ruff@v1` step's `ruff format --check` defaults to double-quoted strings and fails on the file just generated. This repo hasn't hit it yet only because its `tag.yml` hasn't been exercised by a real tag recently.

## Fix
Same fix as pstyle: generate the version file with double quotes.

## Verification
Reproduced the exact shell command locally and confirmed `ruff format --check` passes on the output. `branch` workflow green: https://github.com/wtnb75/dirimport/actions/runs/30813517571

Full `tag.yml` verification requires an actual tag push, left for your next real release.